### PR TITLE
Request throttle

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ If empty, all codes greater than 400 will be marked as failures. Default: `[404,
 - force_get_requests_for_links: List of links for which the tool will use `GET` requests during checks. Default: `[]`.
 - check_web_links: Toggle web link checks on or off. Default: `true`.
 - validate_ssl: Toggles whether to validate SSL certificates when checking web links. Default: `true`.
+- throttle_groups: Number of domain groups to divide requests across for throttling. Default: `100` seconds.
+- throttle_delay: Time to wait between requests, scaled by domain load and group size. Default: `20` seconds.
+- throttle_max_delay: Maximum allowable delay (in seconds) for throttling a single domain. Default: `100` seconds.
 
 > [!TIP]
 > Leverage wildcard patterns ([fnmatch](https://docs.python.org/3/library/fnmatch.html) syntax) for
@@ -150,4 +153,7 @@ check_web_links = true
 catch_response_codes = [404, 410, 500]
 force_get_requests_for_links = []
 validate_ssl = true
+throttle_groups = 100
+throttle_delay = 20
+throttle_max_delay = 100
 ```

--- a/md_dead_link_check/config.py
+++ b/md_dead_link_check/config.py
@@ -23,6 +23,9 @@ class Config:
     force_get_requests_for_links: List[str] = field(default_factory=lambda: [])
     check_web_links: bool = True
     validate_ssl: bool = True
+    throttle_groups: int = 100
+    throttle_delay: int = 20
+    throttle_max_delay: int = 100
 
 
 def get_config(root_dir: Path, config_path: Optional[Path]) -> Config:


### PR DESCRIPTION
Add throttling for request to one domain to avoid `429: too many request` 

New config variables: 
```
- throttle_groups: Number of domain groups to divide requests across for throttling. Default: `100` seconds.
- throttle_delay: Time to wait between requests, scaled by domain load and group size. Default: `20` seconds.
- throttle_max_delay: Maximum allowable delay (in seconds) for throttling a single domain. Default: `100` seconds.
```
