### PR TITLE
Filter url scheme

### DIFF
--- a/md_dead_link_check/link_checker.py
+++ b/md_dead_link_check/link_checker.py
@@ -23,6 +23,7 @@ MSG_PATH_NOT_FOUND = "Path not found"
 MSG_PATH_NOT_ADDED = "Path not added to repository"
 MSG_FRAGMENT_NOT_FOUND = "Fragment not found"
 MSG_UNKNOWN_ERROR = "Unknown error"
+IGNORED_PROTOCOLS = ("ftp", "sftp")
 
 
 @dataclass
@@ -125,6 +126,8 @@ def check_web_links(md_data: Dict[str, MarkdownInfo], config: Config, files: Lis
         if any(fnmatch(md_file, p) for p in config.exclude_files):
             continue
         for li in md_file_info.links:
+            if urlsplit(li.link).scheme in IGNORED_PROTOCOLS:
+                continue
             if any(fnmatch(li.link, p) for p in config.exclude_links):
                 continue
             if urlsplit(li.link).netloc:
@@ -159,7 +162,7 @@ def check_path_links(
             if any(fnmatch(md_link.link, p) for p in config.exclude_links):
                 continue
             split_result = urlsplit(md_link.link)
-            if split_result.netloc:
+            if split_result.scheme or split_result.netloc:
                 continue
             fragment = split_result.fragment.lower()
 

--- a/tests/test_md_files/a.md
+++ b/tests/test_md_files/a.md
@@ -53,3 +53,10 @@ Some text
 #### Some [link](b.md) [link2](b.md)
 
 #### Some tag<a id="id"><a id="id2"></a> asd <a id="id3"></a>
+
+[mail](mailto:example@example.example)
+
+<a href="mailto:example@example.example">mail</a>
+
+[ftp](ftp://example.example/example)
+

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -142,5 +142,20 @@ def test_process_md_file():
             location=Path("tests/test_md_files/a.md"),
             line_num=53,
         ),
+        LinkInfo(
+            link="mailto:example@example.example",
+            location=Path("tests/test_md_files/a.md"),
+            line_num=57,
+        ),
+        LinkInfo(
+            link="mailto:example@example.example",
+            location=Path("tests/test_md_files/a.md"),
+            line_num=59,
+        ),
+        LinkInfo(
+            link="ftp://example.example/example",
+            location=Path("tests/test_md_files/a.md"),
+            line_num=61,
+        ),
     ]
     assert md_info.links == ref_links


### PR DESCRIPTION
Add filter before check links;
- For web links: ignored ftp and sftp protocols
- For local link: ignored any scheme, to ignore links that starts on `mailto:`  or other possible suffix
